### PR TITLE
feat: add optional API key authentication for HTTP server

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "foxhole-inventory-shared",
  "image",
  "serde_json",
+ "subtle",
  "tiny_http",
 ]
 
@@ -1117,6 +1118,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/native/companion/Cargo.toml
+++ b/native/companion/Cargo.toml
@@ -12,5 +12,6 @@ form_urlencoded = "1.2.2"
 foxhole-inventory-shared = { path = "../shared" }
 image = "0.25.9"
 serde_json = "1.0.149"
+subtle = "2.6"
 tiny_http = "0.12.0"
 

--- a/native/companion/Cargo.toml
+++ b/native/companion/Cargo.toml
@@ -12,6 +12,6 @@ form_urlencoded = "1.2.2"
 foxhole-inventory-shared = { path = "../shared" }
 image = "0.25.9"
 serde_json = "1.0.149"
-subtle = "2.6"
+subtle = "2.6.1"
 tiny_http = "0.12.0"
 

--- a/native/companion/src/main.rs
+++ b/native/companion/src/main.rs
@@ -101,17 +101,14 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
     let server = Server::http(addr).map_err(|_| "Failed to start server.")?;
     eprintln!("Listening on http://{}", server.server_addr().to_string());
 
-    // Optional API key authentication via FIR_API_KEY env var.
-    // When set, requests must include an "X-API-Key: <key>" header.
-    // Uses constant-time comparison (subtle crate) to prevent timing attacks.
-    // Note: the key is transmitted in plaintext — configure TLS via a reverse
-    // proxy (e.g. nginx, caddy, or your hosting platform) in production.
-    let api_key = std::env::var("FIR_API_KEY").ok().filter(|k| !k.is_empty());
+    let api_key = std::env::var("FIC_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+        .map(String::into_bytes);
     if api_key.is_some() {
-        eprintln!("API key authentication enabled (X-API-Key header)");
-        eprintln!("Warning: API key is transmitted in plaintext — ensure TLS is configured via reverse proxy");
-    } else {
-        eprintln!("Warning: FIR_API_KEY not set — server is open to all requests");
+        eprintln!(
+            "Warning: API key authentication enabled via HTTP.  Implement a TLS proxy for public/shared networks."
+        );
     }
 
     let (ocr, mut icon_classifier, mut quantity_classifier) = get_classifiers()?;
@@ -139,26 +136,18 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
             continue;
         }
 
-        // Check API key if configured (constant-time comparison)
         if let Some(ref expected_key) = api_key {
-            let provided_key = request
+            let authorized = request
                 .headers()
                 .iter()
-                .find(|h| h.field.equiv("X-API-Key"))
-                .map(|h| h.value.as_str().to_string());
+                .find(|h| h.field.equiv("Authorization"))
+                .and_then(|h| h.value.as_str().strip_prefix("X-API-Key "))
+                .map(|k| k.as_bytes())
+                .is_some_and(|k| k.len() == expected_key.len() && k.ct_eq(expected_key).into());
 
-            let is_valid = provided_key
-                .as_ref()
-                .map(|k| {
-                    k.as_bytes().len() == expected_key.as_bytes().len()
-                        && k.as_bytes().ct_eq(expected_key.as_bytes()).into()
-                })
-                .unwrap_or(false);
-
-            if !is_valid {
+            if !authorized {
                 eprintln!("{remote_addr} {method} {url} 401 {:?}", start.elapsed());
-                let r = Response::from_string("Unauthorized: invalid or missing X-API-Key header")
-                    .with_status_code(StatusCode(401));
+                let r = Response::from_string("Unauthorized").with_status_code(StatusCode(401));
                 let _ = request.respond(r);
                 continue;
             }

--- a/native/companion/src/main.rs
+++ b/native/companion/src/main.rs
@@ -100,6 +100,15 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
     let server = Server::http(addr).map_err(|_| "Failed to start server.")?;
     eprintln!("Listening on http://{}", server.server_addr().to_string());
 
+    // Optional API key authentication via FIR_API_KEY env var.
+    // When set, requests must include "Authorization: Bearer <key>" header.
+    let api_key = std::env::var("FIR_API_KEY").ok().filter(|k| !k.is_empty());
+    if api_key.is_some() {
+        eprintln!("API key authentication enabled");
+    } else {
+        eprintln!("Warning: FIR_API_KEY not set — server is open to all requests");
+    }
+
     let (ocr, mut icon_classifier, mut quantity_classifier) = get_classifiers()?;
     let content_type_header = Header::from_bytes("Content-Type", "application/json").unwrap();
     let catalog = Catalog::new_from_json(CATALOG_JSON)?;
@@ -123,6 +132,29 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
             let r = Response::from_string("Not Found").with_status_code(StatusCode(404));
             let _ = request.respond(r);
             continue;
+        }
+
+        // Check API key if configured
+        if let Some(ref expected_key) = api_key {
+            let auth_header = request
+                .headers()
+                .iter()
+                .find(|h| h.field.equiv("Authorization"))
+                .map(|h| h.value.as_str().to_string());
+
+            let is_valid = auth_header
+                .as_ref()
+                .and_then(|v| v.strip_prefix("Bearer "))
+                .map(|token| token == expected_key)
+                .unwrap_or(false);
+
+            if !is_valid {
+                eprintln!("{remote_addr} {method} {url} 401 {:?}", start.elapsed());
+                let r = Response::from_string("Unauthorized: invalid or missing API key")
+                    .with_status_code(StatusCode(401));
+                let _ = request.respond(r);
+                continue;
+            }
         }
 
         let Ok(includes) = query

--- a/native/companion/src/main.rs
+++ b/native/companion/src/main.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{self, Read};
 
 use form_urlencoded;
+use subtle::ConstantTimeEq;
 use tiny_http::{Header, Method, Response, Server, StatusCode};
 
 use fis::Catalog;
@@ -101,10 +102,14 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
     eprintln!("Listening on http://{}", server.server_addr().to_string());
 
     // Optional API key authentication via FIR_API_KEY env var.
-    // When set, requests must include "Authorization: Bearer <key>" header.
+    // When set, requests must include an "X-API-Key: <key>" header.
+    // Uses constant-time comparison (subtle crate) to prevent timing attacks.
+    // Note: the key is transmitted in plaintext — configure TLS via a reverse
+    // proxy (e.g. nginx, caddy, or your hosting platform) in production.
     let api_key = std::env::var("FIR_API_KEY").ok().filter(|k| !k.is_empty());
     if api_key.is_some() {
-        eprintln!("API key authentication enabled");
+        eprintln!("API key authentication enabled (X-API-Key header)");
+        eprintln!("Warning: API key is transmitted in plaintext — ensure TLS is configured via reverse proxy");
     } else {
         eprintln!("Warning: FIR_API_KEY not set — server is open to all requests");
     }
@@ -134,23 +139,25 @@ fn command_http_server(args: Vec<String>) -> Result<(), Box<dyn std::error::Erro
             continue;
         }
 
-        // Check API key if configured
+        // Check API key if configured (constant-time comparison)
         if let Some(ref expected_key) = api_key {
-            let auth_header = request
+            let provided_key = request
                 .headers()
                 .iter()
-                .find(|h| h.field.equiv("Authorization"))
+                .find(|h| h.field.equiv("X-API-Key"))
                 .map(|h| h.value.as_str().to_string());
 
-            let is_valid = auth_header
+            let is_valid = provided_key
                 .as_ref()
-                .and_then(|v| v.strip_prefix("Bearer "))
-                .map(|token| token == expected_key)
+                .map(|k| {
+                    k.as_bytes().len() == expected_key.as_bytes().len()
+                        && k.as_bytes().ct_eq(expected_key.as_bytes()).into()
+                })
                 .unwrap_or(false);
 
             if !is_valid {
                 eprintln!("{remote_addr} {method} {url} 401 {:?}", start.elapsed());
-                let r = Response::from_string("Unauthorized: invalid or missing API key")
+                let r = Response::from_string("Unauthorized: invalid or missing X-API-Key header")
                     .with_status_code(StatusCode(401));
                 let _ = request.respond(r);
                 continue;


### PR DESCRIPTION
When the FIR_API_KEY environment variable is set, all POST /extract requests must include an Authorization: Bearer <key> header. If the key is missing or invalid, the server returns 401 Unauthorized.

When FIR_API_KEY is not set, the server operates without authentication (backwards compatible with existing deployments).

This allows self-hosted FIR instances to restrict access to authorized clients only, preventing abuse of public deployments.